### PR TITLE
貢ぐフォームとファンになるボタンの実装

### DIFF
--- a/src/main/java/main/AddToOshiMen.java
+++ b/src/main/java/main/AddToOshiMen.java
@@ -1,6 +1,7 @@
 package main;
 
 import java.io.IOException;
+import java.util.List;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
@@ -10,21 +11,20 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-
-import model.*;
-import java.util.*;
+import model.Oshi;
+import model.User;
 
 /**
- * Servlet implementation class GiveMoney
+ * Servlet implementation class AddToOshiMen
  */
-@WebServlet("/GiveMoney")
-public class GiveMoney extends HttpServlet {
+@WebServlet("/AddToOshiMen")
+public class AddToOshiMen extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 
     /**
      * Default constructor. 
      */
-    public GiveMoney() {
+    public AddToOshiMen() {
         // TODO Auto-generated constructor stub
     }
 
@@ -34,7 +34,6 @@ public class GiveMoney extends HttpServlet {
 	 */
 	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		//リクエストパラメータから値を取得
-		int money = Integer.valueOf(request.getParameter("money"));
 		String oshiName = request.getParameter("oshiName");
 		//ユーザをセッションスコープから取得
 		HttpSession session = request.getSession();
@@ -43,19 +42,16 @@ public class GiveMoney extends HttpServlet {
 		ServletContext application = this.getServletContext();
 		@SuppressWarnings("unchecked")
 		List<Oshi> oshiList = (List<Oshi>) application.getAttribute("oshiList"); 
-		//ユーザの総貢ぎ額を更新
-		loginUser.addTotalMoney(money);
-		//推しの総貢がれ額を更新
+		//ユーザの推しメンリストに追加する
 		for(Oshi oshi : oshiList) {
 			if(oshiName.equals(oshi.getName())) {
-				oshi.addTotalMoney(money);
+				oshi.addTotalFans();
+				loginUser.addNewOshi(oshi);
 			}
 		}
-
 		//Main.jspにフォワード
 		RequestDispatcher dispatcher = request.getRequestDispatcher("/Main.jsp");
 		dispatcher.forward(request, response);
-
 	}
 
 }

--- a/src/main/java/main/GiveMoney.java
+++ b/src/main/java/main/GiveMoney.java
@@ -1,0 +1,61 @@
+package main;
+
+import java.io.IOException;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import model.*;
+import java.util.*;
+
+/**
+ * Servlet implementation class GiveMoney
+ */
+@WebServlet("/GiveMoney")
+public class GiveMoney extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+
+    /**
+     * Default constructor. 
+     */
+    public GiveMoney() {
+        // TODO Auto-generated constructor stub
+    }
+
+
+	/**
+	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+	 */
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		//リクエストパラメータから値を取得
+		int money = Integer.valueOf(request.getParameter("money"));
+		String oshiName = request.getParameter("oshiName");
+		//ユーザをセッションスコープから取得
+		HttpSession session = request.getSession();
+		User loginUser = (User) session.getAttribute("loginUser");
+		//推しリストをアプリケーションセッションから取得
+		ServletContext application = this.getServletContext();
+		@SuppressWarnings("unchecked")
+		List<Oshi> oshiList = (List<Oshi>) application.getAttribute("oshiList"); 
+		//ユーザの総貢ぎ額を更新
+		loginUser.addTotalMoney(money);
+		//推しの総貢がれ額を更新
+		for(Oshi oshi : oshiList) {
+			if(oshiName.equals(oshi.getName())) {
+				oshi.addTotalMoney(money);
+			}
+		}
+
+		//main.jspにフォワード
+		RequestDispatcher dispatcher = request.getRequestDispatcher("/Main.jsp");
+		dispatcher.forward(request, response);
+
+	}
+
+}

--- a/src/main/webapp/Main.jsp
+++ b/src/main/webapp/Main.jsp
@@ -38,6 +38,14 @@ List<Oshi> oshiList = (List<Oshi>) application.getAttribute("oshiList");
 					<h3>貢がれた金額: <%=oshiList.get(i).getTotalMoney()%>円</h3>
 					<h3>ファンの人数: <%=oshiList.get(i).getTotalFans()%>人</h3>
 					<h3>作成したユーザー: <%=oshiList.get(i).getUserName()%>さん</h3>
+					<form action="/AirNagesen/GiveMoney" method="post">
+						<label>
+							<input type="text" name="money" /> 円
+						</label>
+				  		<input type="hidden" name="oshiName" value=<%= oshiList.get(i).getName() %> />
+				  		<input type="submit" value="貢ぐ！">
+						
+					</form>
 				</div>
 		<% } %>
 	</div>

--- a/src/main/webapp/Main.jsp
+++ b/src/main/webapp/Main.jsp
@@ -4,6 +4,7 @@
 <%
 User loginUser = (User) session.getAttribute("loginUser");
 List<Oshi> oshiList = (List<Oshi>) application.getAttribute("oshiList");
+List<Oshi> oshiMen = loginUser.getOshiMen();
 %>    
 <!DOCTYPE html>
 <html>
@@ -43,9 +44,16 @@ List<Oshi> oshiList = (List<Oshi>) application.getAttribute("oshiList");
 							<input type="text" name="money" /> 円
 						</label>
 				  		<input type="hidden" name="oshiName" value=<%= oshiList.get(i).getName() %> />
-				  		<input type="submit" value="貢ぐ！">
-						
+				  		<input type="submit" value="貢ぐ！">						
 					</form>
+					<% if(!oshiMen.contains(oshiList.get(i))){ %>
+						<form action="/AirNagesen/AddToOshiMen" method="post">
+							<input type="hidden" name="oshiName" value=<%= oshiList.get(i).getName() %> />
+							<input type="submit" value="推す！" />
+						</form>
+					<% }else{ %>
+						<input type="button" value="推してるなう！" disabled />
+					<% } %>
 				</div>
 		<% } %>
 	</div>


### PR DESCRIPTION
close #15
貢ぐフォームに金額を入れて送信するとユーザーの総貢ぎ額と推しの総貢がれ額を更新する。
「推す！」ボタンを押すと、ユーザーの`oshiMen`に推しを追加し、推しのファン数を１増やす。
新しく推しを作った場合は既に推している(ファンになっている)ものとみなしている。
既に推している(ファンになっている)推しには「推す！」の代わりに「推してるなう！」の押せないボタンを表示している。
（「推してるなう！」ってなんかダサいから他になんかいい文言があったら教えて欲しい🙏）

## ユーザー1から見た一覧画面
<img width="406" alt="スクリーンショット 2021-06-12 0 58 01" src="https://user-images.githubusercontent.com/66374097/121714915-49efb800-cb19-11eb-8842-214cfccc4c69.png">

## ユーザー2から見た一覧画面
<img width="501" alt="スクリーンショット 2021-06-12 0 57 42" src="https://user-images.githubusercontent.com/66374097/121714935-4e1bd580-cb19-11eb-9e32-8d74cdb8e1ef.png">
